### PR TITLE
bootstrap: allow numeric project ID

### DIFF
--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -28,6 +28,10 @@ locals {
   ]
 }
 
+data "google_project" "project" {
+  project_id = var.project
+}
+
 resource "google_project_service" "enable_source_repo" {
   project                    = var.project
   service                    = "sourcerepo.googleapis.com"
@@ -41,7 +45,7 @@ resource "google_project_service" "enable_source_repo" {
 
 resource "google_sourcerepo_repository" "rad_lab_deploy_repo" {
   name = "rad-lab-deploy"
-  project = var.project
+  project = data.google_project.project.name 
 
   depends_on = [
     google_project_service.enable_source_repo


### PR DESCRIPTION
While applying the bootstrapping scripts, I used the numerical project ID (also known as the [project number](https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin)). Surprisingly enough, that actually worked, i.e. Terraform was able to properly create almost all resources except for one: `google_sourcerepo_repository`.

The error appeared as follows:
```
google_sourcerepo_repository.rad_lab_deploy_repo: Creating...
╷
│ Error: Error creating Repository: googleapi: Error 403: The caller does not have permission
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.RequestInfo",
│     "requestId": "181f23ca7514485cb5bf167fb54cebc8"
│   }
│ ]
│ 
│   with google_sourcerepo_repository.rad_lab_deploy_repo,
│   on main.tf line 42, in resource "google_sourcerepo_repository" "rad_lab_deploy_repo":
│   42: resource "google_sourcerepo_repository" "rad_lab_deploy_repo" {
│ 
╵

```

I confirmed that the service account that I used to authenticate had the `roles/source.admin` role assigned. After a bit of head-banging I figured that the project ID might have been at fault. I added the data source to extract information about the project and this way I could convert any project-related string (i.e. project name, project ID or project number) and get the project ID (which is an alphanumeric string). This made the error go away.

I understand that the error was caused by me misusing the variable, however using the data source rather than plain string seemed like a low-hanging fruit to me.