### PR TITLE
bootstrap: document all required roles for service account

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,6 +1,10 @@
 # rad-lab-deploy bootstrap
 
-- add `roles/source.admin` to terraform user
+- Ensure that the following roles are assigned to the service account used to authenticate with Terraform:
+    - `roles/source.admin` (Source Repository Administrator)
+    - `roles/cloudbuild.builds.editor` (Cloud Build Editor)
+    - `roles/resourcemanager.projectIamAdmin` (Project IAM Admin)
+    - `roles/serviceusage.serviceUsageAdmin` (Service Usage Admin)
 - `terraform init`
 - `terraform plan -var project=$PROJECT_ID`
 - `terraform apply -var project=$PROJECT_ID`


### PR DESCRIPTION
This pull request adds a more detailed description of roles required for the service account used for provisioning the initial infrastructure.