### PR TITLE
compute_image.wf.json: disable unattended updates

### DIFF
--- a/rad-lab/modules/silicon_design/scripts/build/images/compute_image.wf.json
+++ b/rad-lab/modules/silicon_design/scripts/build/images/compute_image.wf.json
@@ -59,7 +59,10 @@
 	  "ServiceAccounts": [{
 	    "email": "${service_account}",
 	    "scopes": ["https://www.googleapis.com/auth/devstorage.read_only"]
-	  }]
+	  }],
+	  "Metadata": {
+            "install-unattended-upgrades": "false"
+	  }
         }
       ]
     },


### PR DESCRIPTION
While working on notebooks, we started experiencing build failures. Notably, the build would always fail after circa 45 minutes with an error saying `Error running workflow: step "wait-for-script" did not complete within the specified timeout of 45m0s`.

Initially it was not clear to me what was happening. The provisioning script (`provision.sh`) appeared as though it had hung on `apt-get update` (as the output of that command was the last thing from the script that could be seen):

```shell
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: PWD=/
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: LANG=C.UTF-8
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: INVOCATION_ID=241b7052d024464dae2eee9dd7a39c28
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: SHLVL=1
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: JOURNAL_STREAM=8:38789
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: _=/usr/bin/env
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: DaisyStatus: install system dependencies
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: (Reading database ... #015(Reading database ... 5%#015(Reading database ... 10%#015(Reading database ... 15%#015(Reading database ... 20%#015(Reading database ... 25%#015(Reading database ... 30%#015(Reading database ... 35%#015(Reading database ... 40%#015(Reading database ... 45%#015(Reading database ... 50%#015(Reading database ... 55%#015(Reading database ... 60%#015(Reading database ... 65%#015(Reading database ... 70%#015(Reading database ... 75%#015(Reading database ... 80%#015(Reading database ... 85%#015(Reading database ... 90%#015(Reading database ... 95%#015(Reading database ... 100%#015(Reading database ... 148478 files and directories currently installed.)
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../systemd-sysv_245.4-4ubuntu3.18_amd64.deb ...
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking systemd-sysv (245.4-4ubuntu3.18) over (245.4-4ubuntu3.17) ...
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../libpam-systemd_245.4-4ubuntu3.18_amd64.deb ...
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking libpam-systemd:amd64 (245.4-4ubuntu3.18) over (245.4-4ubuntu3.17) ...
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Hit:1 http://packages.cloud.google.com/apt gcsfuse-focal InRelease
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Hit:2 http://us-east4.gce.archive.ubuntu.com/ubuntu focal InRelease
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Hit:3 http://security.ubuntu.com/ubuntu focal-security InRelease
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Hit:5 http://us-east4.gce.archive.ubuntu.com/ubuntu focal-updates InRelease
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Hit:6 http://us-east4.gce.archive.ubuntu.com/ubuntu focal-backports InRelease
Sep 26 16:03:21 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Get:4 https://packages.cloud.google.com/apt kubernetes-xenial InRelease [9383 B]
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../libpcre2-8-0_10.34-7ubuntu0.1_amd64.deb ...
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking libpcre2-8-0:amd64 (10.34-7ubuntu0.1) over (10.34-7) ...
Sep 26 16:03:21 instance-silicon-design-wl9dl c2d-startup[3350]: Setting up libpcre2-8-0:amd64 (10.34-7ubuntu0.1) ...
Sep 26 16:03:22 instance-silicon-design-wl9dl c2d-startup[3350]: (Reading database ... #015(Reading database ... 5%#015(Reading database ... 10%#015(Reading database ... 15%#015(Reading database ... 20%#015(Reading database ... 25%#015(Reading database ... 30%#015(Reading database ... 35%#015(Reading database ... 40%#015(Reading database ... 45%#015(Reading database ... 50%#015(Reading database ... 55%#015(Reading database ... 60%#015(Reading database ... 65%#015(Reading database ... 70%#015(Reading database ... 75%#015(Reading database ... 80%#015(Reading database ... 85%#015(Reading database ... 90%#015(Reading database ... 95%#015(Reading database ... 100%#015(Reading database ... 148478 files and directories currently installed.)
Sep 26 16:03:22 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../systemd_245.4-4ubuntu3.18_amd64.deb ...
Sep 26 16:03:22 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking systemd (245.4-4ubuntu3.18) over (245.4-4ubuntu3.17) ...
Sep 26 16:03:22 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: 2022/09/26 16:03:22 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.
Sep 26 16:03:22 instance-silicon-design-wl9dl dbus-daemon[602]: [system] Reloaded configuration
Sep 26 16:03:22 instance-silicon-design-wl9dl dbus-daemon[602]: message repeated 12 times: [ [system] Reloaded configuration]
Sep 26 16:03:22 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../libsystemd0_245.4-4ubuntu3.18_amd64.deb ...
Sep 26 16:03:22 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking libsystemd0:amd64 (245.4-4ubuntu3.18) over (245.4-4ubuntu3.17) ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Setting up libsystemd0:amd64 (245.4-4ubuntu3.18) ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: (Reading database ... #015(Reading database ... 5%#015(Reading database ... 10%#015(Reading database ... 15%#015(Reading database ... 20%#015(Reading database ... 25%#015(Reading database ... 30%#015(Reading database ... 35%#015(Reading database ... 40%#015(Reading database ... 45%#015(Reading database ... 50%#015(Reading database ... 55%#015(Reading database ... 60%#015(Reading database ... 65%#015(Reading database ... 70%#015(Reading database ... 75%#015(Reading database ... 80%#015(Reading database ... 85%#015(Reading database ... 90%#015(Reading database ... 95%#015(Reading database ... 100%#015(Reading database ... 148478 files and directories currently installed.)
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../00-libsqlite3-0_3.31.1-4ubuntu0.4_amd64.deb ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking libsqlite3-0:amd64 (3.31.1-4ubuntu0.4) over (3.31.1-4ubuntu0.3) ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../01-xxd_2%3a8.1.2269-1ubuntu5.9_amd64.deb ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking xxd (2:8.1.2269-1ubuntu5.9) over (2:8.1.2269-1ubuntu5.7) ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../02-bind9-dnsutils_1%3a9.16.1-0ubuntu2.11_amd64.deb ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking bind9-dnsutils (1:9.16.1-0ubuntu2.11) over (1:9.16.1-0ubuntu2.10) ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../03-bind9-libs_1%3a9.16.1-0ubuntu2.11_amd64.deb ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking bind9-libs:amd64 (1:9.16.1-0ubuntu2.11) over (1:9.16.1-0ubuntu2.10) ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../04-bind9-host_1%3a9.16.1-0ubuntu2.11_amd64.deb ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking bind9-host (1:9.16.1-0ubuntu2.11) over (1:9.16.1-0ubuntu2.10) ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../05-kubectl_1.25.2-00_amd64.deb ...
Sep 26 16:03:23 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking kubectl (1.25.2-00) over (1.25.1-00) ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../06-libjpeg-turbo8-dev_2.0.3-0ubuntu1.20.04.3_amd64.deb ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking libjpeg-turbo8-dev:amd64 (2.0.3-0ubuntu1.20.04.3) over (2.0.3-0ubuntu1.20.04.1) ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../07-libjpeg-turbo8_2.0.3-0ubuntu1.20.04.3_amd64.deb ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking libjpeg-turbo8:amd64 (2.0.3-0ubuntu1.20.04.3) over (2.0.3-0ubuntu1.20.04.1) ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../08-libtiff5_4.1.0+git191117-2ubuntu0.20.04.5_amd64.deb ...
Sep 26 16:03:25 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Fetched 9383 B in 1s (12.9 kB/s)
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking libtiff5:amd64 (4.1.0+git191117-2ubuntu0.20.04.5) over (4.1.0+git191117-2ubuntu0.20.04.4) ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../09-linux-libc-dev_5.4.0-126.142_amd64.deb ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking linux-libc-dev:amd64 (5.4.0-126.142) over (5.4.0-125.141) ...
Sep 26 16:03:25 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../10-sosreport_4.3-1ubuntu0.20.04.2_amd64.deb ...
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking sosreport (4.3-1ubuntu0.20.04.2) over (4.3-1ubuntu0.20.04.1) ...
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Preparing to unpack .../11-gcsfuse_0.41.7_amd64.deb ...
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Unpacking gcsfuse (0.41.7) over (0.41.6) ...
Sep 26 16:03:26 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: 2022/09/26 16:03:26 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Setting up gcsfuse (0.41.7) ...
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Setting up bind9-libs:amd64 (1:9.16.1-0ubuntu2.11) ...
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Setting up libsqlite3-0:amd64 (3.31.1-4ubuntu0.4) ...
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Setting up linux-libc-dev:amd64 (5.4.0-126.142) ...
Sep 26 16:03:26 instance-silicon-design-wl9dl c2d-startup[3350]: Setting up systemd (245.4-4ubuntu3.18) ...
Sep 26 16:03:26 instance-silicon-design-wl9dl google_metadata_script_runner[3731]: startup-script-url: Reading package lists...
Sep 26 16:03:26 instance-silicon-design-wl9dl systemd[1]: Reexecuting.
Sep 26 16:03:26 instance-silicon-design-wl9dl kernel: [  108.908313] systemd[1]: systemd 245.4-4ubuntu3.18 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=hybrid)
Sep 26 16:03:26 instance-silicon-design-wl9dl kernel: [  108.908410] systemd[1]: Detected virtualization kvm.
Sep 26 16:03:26 instance-silicon-design-wl9dl kernel: [  108.908417] systemd[1]: Detected architecture x86-64.
Sep 26 16:03:27 instance-silicon-design-wl9dl systemd[1]: cgroup compatibility translation between legacy and unified hierarchy settings activated. See cgroup-compat debug messages for details.
         Stopping [0;1;39mGoogle Compute Engine Guest Agent[0m...
[[0;32m  OK  [0m] Stopped [0;1;39mWait for Network to be Configured[0m.
         Stopping [0;1;39mWait for Network to be Configured[0m...
Sep 26 16:03:27 instance-silicon-design-wl9dl google_guest_agent[775]: GCE Agent Stopped
Sep 26 16:03:27 instance-silicon-design-wl9dl systemd[1]: Stopping Google Compute Engine Guest Agent...
Sep 26 16:03:27 instance-silicon-design-wl9dl systemd[1]: Condition check resulted in OpenVSwitch configuration for cleanup being skipped.
Sep 26 16:03:27 instance-silicon-design-wl9dl systemd[1]: systemd-networkd-wait-online.service: Succeeded.
Sep 26 16:03:27 instance-silicon-design-wl9dl systemd[1]: Stopped Wait for Network to be Configured.
Sep 26 16:03:27 instance-silicon-design-wl9dl systemd[1]: Stopping Wait for Network to be Configured...
Sep 26 16:03:27 instance-silicon-design-wl9dl systemd[1]: google-guest-agent.service: Succeeded.
```

What I managed to work out, however, is that it wouldn't get stuck; instead, it would simply stop running altogether. I proved that it was the case by adding a simple while loop that would print something every second. At some point it would simply stop.

Digging further, it seemed that another `apt update` process was the culprit. I looked at previous (successful) runs and the only factor that appeared to have been different back then was the lack of logs hinting that `systemd` was being updated.

Therefore, it occurred to me that perhaps `systemd`, upon being restarted by `dpkg` hooks, would do something funny to one of its units responsible for running the [GCP VM startup script](https://cloud.google.com/compute/docs/instances/startup-scripts/linux) (as this is the mechanism that is used by Daisy to run the provision.sh script).

Upon closer inspection, I established that the script responsible for starting that update was located in `/opt/c2d/98-enable-updates.sh`.

The content of that script looks as follows:
```bash
#!/bin/bash -eu
#
# Copyright 2017 Google Inc.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

# shellcheck source=build/vm/packer/clean/files/c2d/c2d-utils disable=SC1091
source /opt/c2d/c2d-utils || exit 1


function should_install_unattended_upgrades() {
  local install_unattended_upgrades=true
  if [[ -n "$(get_attribute_value install-unattended-upgrades)" ]]; then
    install_unattended_upgrades="$(get_attribute_value install-unattended-upgrades)"
  fi
  if [[ "$install_unattended_upgrades" = true ]]; then
    unattended_upgrades_setup || echo "Unattended upgrades setup installation failed" >&2
  fi
}

function unattended_upgrades_setup() {
  echo "Installing unattended upgrades..."
  # enable background update services
  if has_internet_connection; then
    # make sure system is up to date in background
    apt-get --allow-releaseinfo-change update || {
      echo "apt-get --allow-releaseinfo-change update failed!"
      exit 1
    }
    DEBIAN_FRONTEND=noninteractive apt -y upgrade & disown
    # enable background update services
    systemctl enable --now apt-daily-upgrade.timer
    systemctl enable --now apt-daily.timer
    systemctl enable unattended-upgrades.service
  fi
}


function main() {
  set_system_status_message "UNATTENDED_UPGRADES_SETUP"
  shopt -s nocasematch
  should_install_unattended_upgrades
  shopt -u nocasematch
}

main
```

Bingo! We can clearly see that timers related to `apt` are activated, and they start immediately, thus messing with the `Google Compute Engine Startup Scripts` unit.

My initial solution to this problem that I came up with was to add some steps to `compute_image.wf.json` that create an intermediate Compute Engine instance with two disks attached (one Debian 11 boot disk, and another one based on the image that would eventually make its way to the proper instance) and with a startup script that mounts the secondary drive and removes the offending file.

This did work but I inspected the script again and I arrived at a simpler solution: I set the `install-unattended-upgrades` metadata variable to a falsy value and that effectively neutralizes the script.

As to why this didn't crop up before, there are two hypotheses:
* looking at the [Deep Learning VM release notes](https://cloud.google.com/deep-learning-vm/docs/release-notes) it seems that an update has been rolled out recently (on September 20th) and it is possible that this introduced this regression (perhaps it should be escalated further; in the meantime we implemented this provisional fix).
* there was no update for `systemd` to be applied up until now.

Please note that you may not experience this bug if you've already built the image a while ago and hasn't changed anything; then the rebuild won't be triggered. A full rebuild can be easily triggered by pushing the branch under a different name.