### PR TITLE
Use combined SHA of all notebook-related files as a trigger

### DIFF
--- a/rad-lab/modules/silicon_design/main.tf
+++ b/rad-lab/modules/silicon_design/main.tf
@@ -311,7 +311,7 @@ resource "null_resource" "build_and_push_image" {
     env_sha        = filesha1("${path.module}/scripts/build/images/provision/install.tcl")
     profile_sha        = filesha1("${path.module}/scripts/build/images/provision/profile.sh")
     papermill_sha        = filesha1("${path.module}/scripts/build/images/provision/papermill-launcher")
-    notebook_sha        = filesha1("${path.module}/scripts/build/notebooks/examples/digital/inverter/inverter.md")
+    notebook_sha        = sha1(join("", [for f in fileset(path.cwd, "scripts/build/notebooks/**/*"): filesha1(f)]))
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
While adding some new notebooks, we came across the issue where making amendments to them weren't triggering the [secondary build](https://github.com/proppy/rad-lab-deploy/blob/tuning/rad-lab/modules/silicon_design/scripts/build/cloudbuild.yaml) which synchronizes the changes with the staging bucket.

I took a look at the code and this turned out to have been caused by the fact that there was no explicit trigger for our files.

This pull request changes that so that any modifications made to files under `scripts/build/notebooks` will trigger the build. The downside is that this will also cause other, long-running, steps to run (as a consequence the build takes circa 30 minutes) which have nothing to do with running `gsutil` but that is a separate issue that we briefly mentioned in https://github.com/proppy/rad-lab-deploy/pull/3.