### PR TITLE
Fetch RADLab notebook machine type from project metadata variables

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,6 +23,15 @@ steps:
     gsutil ls gs://$PROJECT_ID-tfstate || gsutil mb gs://$PROJECT_ID-tfstate
     (gsutil versioning get gs://$PROJECT_ID-tfstate | grep Enabled) || gsutil versioning set on gs://$PROJECT_ID-tfstate
 
+- id: 'get machine type'
+  name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |-
+      apt -qqy update && apt -qqy install jq
+      (gcloud --format=json compute project-info describe | jq -e -r '.commonInstanceMetadata.items[] | select(.key == "radlab-machine-type") | .value' || printf "n2-standard-32") > /workspace/radlab_machine_type
+
 - id: 'tf init'
   name: 'hashicorp/terraform:latest'
   env:
@@ -55,6 +64,7 @@ steps:
   args:
   - '-c'
   - |-
+    export TF_VAR_machine_type=$(cat /workspace/radlab_machine_type)
     terraform plan
 
 - id: 'tf apply'
@@ -75,4 +85,5 @@ steps:
     gcloud config set core/disable_usage_reporting true
     gcloud config set component_manager/disable_update_check true
     gcloud --version
+    export TF_VAR_machine_type=$(cat /workspace/radlab_machine_type)
     terraform apply -auto-approve

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ module "radlab_silicon_deploy" {
   set_external_ip_policy          = false
   set_shielded_vm_policy          = false
   set_trustedimage_project_policy = false
-  machine_type			  = "n2-standard-32"
+  machine_type			  = var.machine_type 
 
   notebook_count = 1
   notebook_names = [

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,7 @@
 
 variable "project" {}
 variable "env" {}
+variable "machine_type" {
+  type    = string
+  default = "n2-standard-32"
+}


### PR DESCRIPTION
While testing your recent rebase, we hit a quota for `N2` CPUs in the region specified in Terraform files. This was caused by the fact that one of the commits had changed the default notebook instance type. Instead of changing it back, we developed a more permanent solution which makes it possible to specify this parameter by means of a project-level instance metadata (just add a variable with the `radlab-machine-type` key and the desired value in [Compute Engine Metadata](https://console.cloud.google.com/compute/metadata)).

I believe that it makes sense to make it possible to specify this parameter in the GCP project, as quotas are project-specific. The added benefit is that it doesn't change the flow if you don't need to change this value (it will default to `n2-standard-32` if the project metadata variable is not found).